### PR TITLE
Swagger 설치 및 API 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-orgjson:0.11.2'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'com.mysql:mysql-connector-j'
+   	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/rgt/book/BookController.java
+++ b/src/main/java/com/rgt/book/BookController.java
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.rgt.book.dto.CreateBookDTO;
 import com.rgt.book.dto.UpdateBookDTO;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,16 +31,11 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/books")
+@Tag(name = "Books", description = "도서 관련 API")
 public class BookController {
 	private final BookService bookService;
 	
-	@PreAuthorize("hasRole('ADMIN')")
-	@GetMapping("/test")
-	public String test() {
-		return "hi";
-	}
-	
-	
+	@Operation(summary = "도서 목록 조회", description = "검색어와 페이지 정보를 통해 도서 목록을 조회합니다.")
 	@GetMapping
 	public ResponseEntity<?> getBooks(
 	        @RequestParam(name = "searchTerm", required = false) String searchTerm, 
@@ -53,6 +50,7 @@ public class BookController {
 	    }
 	}
     
+	@Operation(summary = "특정 도서 조회", description = "ID로 특정 도서를 조회합니다.")
 	@GetMapping("/{id}")
 	public ResponseEntity<?> getBook(@PathVariable("id") Long id) {
 	    try {
@@ -67,6 +65,7 @@ public class BookController {
 	    }
 	}
 	
+	@Operation(summary = "새 도서 등록", description = "새로운 도서를 등록합니다.")
 	@PreAuthorize("hasRole('ADMIN')")
     @PostMapping
     public ResponseEntity<?> createBook(@RequestBody CreateBookDTO createBookDTO) {
@@ -88,6 +87,7 @@ public class BookController {
     }
     
 	@PreAuthorize("hasRole('ADMIN')")
+	@Operation(summary = "도서 정보 수정", description = "ID로 도서 정보를 수정합니다.")
     @PutMapping("/{id}")
     public ResponseEntity<?> updateBook(@PathVariable("id") Long id, @RequestBody UpdateBookDTO updateBookDTO){
     	try {
@@ -100,6 +100,7 @@ public class BookController {
     }
 	
 	@PreAuthorize("hasRole('ADMIN')")
+	@Operation(summary = "도서 삭제", description = "ID로 도서를 삭제합니다.")
 	@DeleteMapping("/{id}")
 	public ResponseEntity<?> deleteBook(@PathVariable("id") Long id) {
 	    try {

--- a/src/main/java/com/rgt/lib/swagger/SwaggerConfig.java
+++ b/src/main/java/com/rgt/lib/swagger/SwaggerConfig.java
@@ -1,0 +1,42 @@
+package com.rgt.lib.swagger;
+
+
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @io.swagger.v3.oas.annotations.info.Info(title = "BookStore API 명세서",
+                description = "BookStore API 명세서",
+                version = "v1"))
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        String jwt = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+                .name(jwt)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+        );
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+    private Info apiInfo() {
+        return new Info()
+                .title("API Test") // API의 제목
+                .description("BookStore Swagger UI") // API에 대한 설명
+                .version("1.0.0"); // API의 버전
+    }
+}

--- a/src/main/java/com/rgt/user/UserController.java
+++ b/src/main/java/com/rgt/user/UserController.java
@@ -18,6 +18,8 @@ import com.rgt.user.dto.CreateUserDTO;
 import com.rgt.user.dto.LoginDTO;
 import com.rgt.user.dto.ResponseUserDTO;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -27,11 +29,12 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
+@Tag(name = "Authentication", description = "사용자 인증 관련 API")
 public class UserController {
 	private final UserService userService;
 	private final TokenProvider tokenProvider;
 	
-
+    @Operation(summary = "사용자 가입", description = "새로운 사용자를 등록합니다.")
     @PostMapping("/signup")
     public ResponseEntity<?> registerUser(@RequestBody CreateUserDTO createUserDTO) {
         try {
@@ -47,6 +50,7 @@ public class UserController {
         }
     }
     
+    @Operation(summary = "사용자 로그인", description = "사용자를 인증하고 액세스 토큰을 생성합니다.")
     @PostMapping("/login")
     public ResponseEntity<?> authenticate(HttpServletResponse response, @RequestBody LoginDTO loginDTO) {
         try {
@@ -75,6 +79,7 @@ public class UserController {
     }
 
     
+    @Operation(summary = "사용자 로그아웃", description = "사용자를 로그아웃하고 인증 정보를 제거합니다.")
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
         try {


### PR DESCRIPTION
# 🛡️ Swagger 설치 및 API 문서화

## 🐛 관련 이슈
- 없음

## 🔄 변경 사항
- UserController 및 BookController 클래스에 Swagger 어노테이션 추가
- 각 API 메서드에 대한 설명 및 응답 상태 코드 명세 작성
- springdoc-openapi-ui 라이브러리 추가
- Gradle 의존성에 Swagger UI를 위한 라이브러리 추가
- Swagger UI 설정을 통해 `/swagger-ui.html` 경로에서 API 문서에 접근 가능하도록 설정

## 📌 변경 이유
- API의 가독성을 높이고, 명확한 문서화를 통해 개발자 및 사용자 간의 소통을 원활하게 하기 위함입니다.
- Swagger를 통해 자동으로 생성되는 API 문서로, 유지보수 및 테스트 효율성을 향상시키기 위함입니다.

## ✅ 테스트 방법
1. 프로젝트를 실행합니다.
2. 브라우저에서 `{백엔드 주소}/swagger-ui.html`로 이동합니다.
3. Swagger UI에서 각 API 엔드포인트를 확인하고, 문서화된 내용을 검토합니다.

## 📷 스크린샷
- 없음

## ℹ️ 추가 정보
- 특별한 추가 정보는 없습니다.
